### PR TITLE
[wip] poc proxified forest

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -568,7 +568,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
     // (undocumented)
     attachRangeOfChildren(destination: TreeLocation, toAttach: DetachedField): void;
     // (undocumented)
-    readonly currentCursors: Set<Cursor>;
+    readonly currentCursors: Set<ITreeCursor>;
     // (undocumented)
     delete(range: DetachedField): void;
     // (undocumented)

--- a/experimental/PropertyDDS/examples/property-inspector/src/forestInspector/proplikeTable.tsx
+++ b/experimental/PropertyDDS/examples/property-inspector/src/forestInspector/proplikeTable.tsx
@@ -1,0 +1,65 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import * as React from "react";
+
+import {
+    // handlePropertyDataCreation,
+    fetchRegisteredTemplates,
+    IDataCreationOptions,
+    IInspectorRow,
+    IInspectorTableProps,
+    InspectorTable,
+    fillExpanded,
+    nameCellRenderer,
+    valueCellRenderer,
+    typeCellRenderer,
+    toTableRows,
+    generateForm,
+    addDataForm,
+    expandAll,
+    getDefaultInspectorTableIcons,
+} from "@fluid-experimental/property-inspector-table";
+
+export const handleDataCreationOptionGeneration = (rowData: IInspectorRow, nameOnly: boolean): IDataCreationOptions => {
+    if (nameOnly) {
+        return { name: "property" };
+    }
+    const templates = fetchRegisteredTemplates();
+    return { name: "property", options: templates };
+};
+
+export const propertyTableProps: Partial<IInspectorTableProps> = {
+    columns: ["name", "value", "type"],
+    expandColumnKey: "name",
+    width: 1000,
+    height: 600,
+    dataCreationHandler: async (rowData: any, name: string, typeid: string, context: string): Promise<any> => {
+        if (typeid.startsWith("String") && context === "single") {
+            rowData.parent[name] = "";
+        } else if (context === "single" && typeid.startsWith("Int")) {
+            rowData.parent[name] = 0;
+        } else if (context === "single" && typeid.startsWith("Float")) {
+            rowData.parent[name] = 0.0;
+        }
+
+        return new Promise((resolve) => resolve(true));
+    },
+    dataCreationOptionGenerationHandler: handleDataCreationOptionGeneration,
+    fillExpanded,
+    toTableRows,
+    expandAll,
+    generateForm,
+    rowIconRenderer: getDefaultInspectorTableIcons,
+    addDataForm,
+    columnsRenderers: {
+        name: nameCellRenderer,
+        value: valueCellRenderer,
+        type: typeCellRenderer,
+    },
+};
+
+export const ProplikeTable = (props: IInspectorTableProps) => {
+    return <InspectorTable {...propertyTableProps} {...props} />;
+};

--- a/experimental/PropertyDDS/examples/property-inspector/src/forestInspector/proxyTable.tsx
+++ b/experimental/PropertyDDS/examples/property-inspector/src/forestInspector/proxyTable.tsx
@@ -1,3 +1,7 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
 import * as React from "react";
 
 import { Box, Chip, Switch, TextField, FormLabel, Button } from "@material-ui/core";
@@ -7,14 +11,19 @@ import {
     IInspectorTableProps,
     InspectorTable,
     IToTableRowsOptions,
-    IToTableRowsProps,
     typeidToIconMap,
 } from "@fluid-experimental/property-inspector-table";
-import AutoSizer from "react-virtualized-auto-sizer";
 
-import { jsonArray, jsonString, jsonBoolean, jsonNumber, JsonCursor } from "@fluid-internal/tree";
+import { TreeNavigationResult,
+    jsonArray, jsonString, jsonBoolean, jsonNumber,
+    ObjectForest,
+    ITreeCursor,
+} from "@fluid-internal/tree";
 
 import { IInspectorRowData, getDataFromCursor } from "../cursorData";
+
+import { convertPSetSchema } from "../schemaConverter";
+import { getForestProxy } from "../forestProxy";
 
 const useStyles = makeStyles({
     boolColor: {
@@ -55,17 +64,36 @@ const useStyles = makeStyles({
     },
 }, { name: "JsonTable" });
 
-const toTableRows = ({ data }: Partial<IInspectorRowData>, props: IToTableRowsProps,
+export type IProxyTableProps = IInspectorTableProps;
+
+const toTableRows = ({ data: forest }: Partial<IInspectorRowData>, props: any,
     _options?: Partial<IToTableRowsOptions>, _pathPrefix?: string,
 ): IInspectorRowData[] => {
-    const jsonCursor = new JsonCursor(data);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return getDataFromCursor(jsonCursor, [], props.readOnly);
+    const rootId = props.documentId;
+    if (!forest) {
+        return [];
+    }
+    const reader: ITreeCursor = forest.allocateCursor();
+    const result = forest.tryGet(forest.root(forest.rootField), reader);
+    const trees = forest.getRoot(forest.rootField);
+    if (result === TreeNavigationResult.Ok && trees?.length) {
+        return getDataFromCursor(reader, [], props.readOnly, rootId);
+    }
+    return [];
 };
 
-export type IJsonTableProps = IInspectorTableProps;
+export const getForest = (data) => {
+    const forest: ObjectForest = new ObjectForest();
+    convertPSetSchema("Test:Person-1.0.0", forest.schema);
+    if (data) {
+        // Not sure how best to create data from Schema
+        // eslint-disable-next-line @typescript-eslint/dot-notation
+        window["__proxy"] = getForestProxy(data, forest, 0);
+    }
+    return forest;
+};
 
-const jsonTableProps: Partial<IJsonTableProps> = {
+const forestTableProps: Partial<IProxyTableProps> = {
     columns: ["name", "value", "type"],
     expandColumnKey: "name",
     toTableRows,
@@ -76,38 +104,24 @@ const jsonTableProps: Partial<IJsonTableProps> = {
         },
     }),
     dataCreationHandler: async () => { },
-    addDataForm: ({ styleClass }) => {
-        return (
-            <AutoSizer defaultHeight={200} defaultWidth={200}>
-                {({ width, height }) => (
-                    <div style={{
-                        height: `${height - 20}px`,
-                        width: `${width - 20}px`,
-                    }}>
-                        <Box
-                            className={styleClass}
-                            sx={{
-                                display: "flex",
-                                flexDirection: "column",
-                            }}>
-                            <Box sx={{ display: "flex", height: "75px" }}>
-                                <TextField label="name"></TextField>
-                                <TextField label="value"></TextField>
-                            </Box>
-                            <Box sx={{ display: "flex", height: "75px" }}>
-                                <Button>Cancel</Button>
-                                <Button>Create</Button>
-                            </Box>
-                        </Box>
-                    </div>)
-                }
-            </AutoSizer >);
+    addDataForm: () => {
+        return (<Box sx={{ display: "flex", flexDirection: "column", height: "160px" }}>
+            <Box sx={{ display: "flex", height: "75px" }}>
+                <TextField label="name"></TextField>
+                <TextField label="value"></TextField>
+            </Box>
+            <Box sx={{ display: "flex", height: "75px" }}>
+                <Button>Cancel</Button>
+                <Button>Create</Button>
+            </Box>
+        </Box>);
     },
     generateForm: () => {
         return true;
     },
     // TODO: // Fix types
     rowIconRenderer: (rowData: any) => {
+        console.log(rowData.type);
         switch (rowData.type) {
             case "String":
             case "Array":
@@ -120,10 +134,11 @@ const jsonTableProps: Partial<IJsonTableProps> = {
     height: 600,
 };
 
-export const JsonTable = (props: IJsonTableProps) => {
+export const ProxyTable = (props: IProxyTableProps) => {
     const classes = useStyles();
+
     return <InspectorTable
-        {...jsonTableProps}
+        {...forestTableProps}
         columnsRenderers={
             {
                 name: ({ rowData, cellData, renderCreationRow, tableProps: { readOnly } }) => {
@@ -156,6 +171,7 @@ export const JsonTable = (props: IJsonTableProps) => {
                             />;
 
                         case jsonString.name:
+                        case "String":
                             return <TextField value={value}
                                 disabled={!!readOnly} type="string" />;
                         case jsonNumber.name:

--- a/experimental/PropertyDDS/examples/property-inspector/src/inspector.tsx
+++ b/experimental/PropertyDDS/examples/property-inspector/src/inspector.tsx
@@ -19,11 +19,15 @@ import AutoSizer from "react-virtualized-auto-sizer";
 
 import { Box, Tabs, Tab } from "@material-ui/core";
 import ReactJson from "react-json-view";
+
+import { brand, JsonableTree } from "@fluid-internal/tree";
+
 import { theme } from "./theme";
 import { PropertyTable } from "./propertyInspector/propertyTable";
 import { loadPropertyDDS } from "./propertyInspector/propertyData";
 import { JsonTable } from "./jsonInspector/jsonTable";
 import { ForestTable, getForest } from "./forestInspector/forestTable";
+import { ProxyTable, getForest as getForestProxy } from "./forestInspector/proxyTable";
 
 const useStyles = makeStyles({
     activeGraph: {
@@ -154,10 +158,24 @@ function TabPanel(props: TabPanelProps) {
     );
 }
 
+const customTypeData: JsonableTree = {
+    type: brand("Test:Person-1.0.0"),
+    fields: {
+        name: [{ value: "Adam", type: brand("String") }],
+        address: [{
+            fields: {
+                street: [{ value: "treeStreet", type: brand("String") }],
+            },
+            type: brand("Test:Address-1.0.0"),
+         }],
+    },
+};
+
 export const InspectorApp = (props: any) => {
     const classes = useStyles();
     const [json, setJson] = useState(customData);
     const [forest, setForest] = useState(getForest(customData));
+    const [forestProxy/* setForestProxy */] = useState(getForestProxy(customTypeData));
     const [tabIndex, setTabIndex] = useState(0);
 
     const onJsonEdit = ({ updated_src }) => {
@@ -175,7 +193,8 @@ export const InspectorApp = (props: any) => {
                         <Box sx={{ display: "flex", flexDirection: "row", width: "100%" }}>
                                 <Box sx={{ display: "flex", flexDirection: "column", width: "75%" }}>
                                     <Tabs value={tabIndex} onChange={(event, newTabIndex) => setTabIndex(newTabIndex)}>
-                                        <Tab label="Forest Cursor" id="tab-forestCursor"/>
+                                        <Tab label="Custom Type (Forest Proxy)" id="tab-proxyForest"/>
+                                        <Tab label="Forest Cursors" id="tab-forestCursor"/>
                                         <Tab label="JSON Cursor" id="tab-jsonCursor"/>
                                         <Tab label="PropertyDDS" id="tab-propertyDDS"/>
                                     </Tabs>
@@ -183,7 +202,7 @@ export const InspectorApp = (props: any) => {
                                     {
                                         ({ width, height }) =>
                                             <Box sx={{ display: "flex" }}>
-                                                <TabPanel value={tabIndex} index={2}>
+                                                <TabPanel value={tabIndex} index={3}>
                                                     <PropertyTable
                                                         // readOnly={true}
                                                         width={width}
@@ -191,7 +210,7 @@ export const InspectorApp = (props: any) => {
                                                         {...props}
                                                     />
                                                 </TabPanel>
-                                                <TabPanel value={tabIndex} index={1}>
+                                                <TabPanel value={tabIndex} index={2}>
                                                     <JsonTable
                                                         readOnly={false}
                                                         width={width}
@@ -200,13 +219,22 @@ export const InspectorApp = (props: any) => {
                                                         data={json}
                                                     />
                                                 </TabPanel>
-                                                <TabPanel value={tabIndex} index={0}>
+                                                <TabPanel value={tabIndex} index={1}>
                                                     <ForestTable
                                                         readOnly={false}
                                                         width={width}
                                                         height={height}
                                                         {...props}
                                                         data={forest}
+                                                    />
+                                                </TabPanel>
+                                                <TabPanel value={tabIndex} index={0}>
+                                                    <ProxyTable
+                                                        readOnly={false}
+                                                        width={width}
+                                                        height={height}
+                                                        {...props}
+                                                        data={forestProxy}
                                                     />
                                                 </TabPanel>
                                             </Box>

--- a/experimental/PropertyDDS/examples/property-inspector/src/inspector.tsx
+++ b/experimental/PropertyDDS/examples/property-inspector/src/inspector.tsx
@@ -175,7 +175,7 @@ export const InspectorApp = (props: any) => {
     const classes = useStyles();
     const [json, setJson] = useState(customData);
     const [forest, setForest] = useState(getForest(customData));
-    const [forestProxy/* setForestProxy */] = useState(getForestProxy(customTypeData));
+    const forestProxy = getForestProxy(customTypeData, props.renderer);
     const [tabIndex, setTabIndex] = useState(0);
 
     const onJsonEdit = ({ updated_src }) => {
@@ -193,7 +193,7 @@ export const InspectorApp = (props: any) => {
                         <Box sx={{ display: "flex", flexDirection: "row", width: "100%" }}>
                                 <Box sx={{ display: "flex", flexDirection: "column", width: "75%" }}>
                                     <Tabs value={tabIndex} onChange={(event, newTabIndex) => setTabIndex(newTabIndex)}>
-                                        <Tab label="Custom Type (Forest Proxy)" id="tab-proxyForest"/>
+                                        <Tab label="Forest Proxy" id="tab-proxyForest"/>
                                         <Tab label="Forest Cursors" id="tab-forestCursor"/>
                                         <Tab label="JSON Cursor" id="tab-jsonCursor"/>
                                         <Tab label="PropertyDDS" id="tab-propertyDDS"/>
@@ -253,10 +253,11 @@ export const InspectorApp = (props: any) => {
 };
 
 export async function renderApp(element: HTMLElement, documentId: string, shouldCreateNew?: boolean, data?: any) {
+    const render = async (newData: any) => renderApp(element, documentId, false, newData);
     const propertyDDS = data || await loadPropertyDDS({
         documentId,
         shouldCreateNew,
-        render: async (newData: any) => renderApp(element, documentId, false, newData),
+        render,
     });
-    ReactDOM.render(<InspectorApp data={propertyDDS} documentId={documentId}/>, element);
+    ReactDOM.render(<InspectorApp data={propertyDDS} documentId={documentId} renderer={render}/>, element);
 }

--- a/experimental/PropertyDDS/examples/property-inspector/src/inspector.tsx
+++ b/experimental/PropertyDDS/examples/property-inspector/src/inspector.tsx
@@ -26,8 +26,9 @@ import { theme } from "./theme";
 import { PropertyTable } from "./propertyInspector/propertyTable";
 import { loadPropertyDDS } from "./propertyInspector/propertyData";
 import { JsonTable } from "./jsonInspector/jsonTable";
-import { ForestTable, getForest } from "./forestInspector/forestTable";
+// import { ForestTable, getForest } from "./forestInspector/forestTable";
 import { ProxyTable, getForestProxy } from "./forestInspector/proxyTable";
+import { ProplikeTable } from "./forestInspector/proplikeTable";
 
 const useStyles = makeStyles({
     activeGraph: {
@@ -161,7 +162,9 @@ function TabPanel(props: TabPanelProps) {
 const customTypeData: JsonableTree = {
     type: brand("Test:Person-1.0.0"),
     fields: {
-        name: [{ value: "Adam", type: brand("String") }],
+        name: [
+            { value: "Adam", type: brand("String") },
+        ],
         address: [{
             fields: {
                 street: [{ value: "treeStreet", type: brand("String") }],
@@ -174,13 +177,13 @@ const customTypeData: JsonableTree = {
 export const InspectorApp = (props: any) => {
     const classes = useStyles();
     const [json, setJson] = useState(customData);
-    const [forest, setForest] = useState(getForest(customData));
+    // const [forest, setForest] = useState(getForest(customData));
     const forestProxy = getForestProxy(customTypeData, props.renderer);
     const [tabIndex, setTabIndex] = useState(0);
 
     const onJsonEdit = ({ updated_src }) => {
         setJson(updated_src);
-        setForest(getForest(updated_src));
+        // setForest(getForest(updated_src));
     };
 
     return (
@@ -193,8 +196,8 @@ export const InspectorApp = (props: any) => {
                         <Box sx={{ display: "flex", flexDirection: "row", width: "100%" }}>
                                 <Box sx={{ display: "flex", flexDirection: "column", width: "75%" }}>
                                     <Tabs value={tabIndex} onChange={(event, newTabIndex) => setTabIndex(newTabIndex)}>
+                                        <Tab label="Proplike Proxy" id="tab-proplikeProxy"/>
                                         <Tab label="Forest Proxy" id="tab-proxyForest"/>
-                                        <Tab label="Forest Cursors" id="tab-forestCursor"/>
                                         <Tab label="JSON Cursor" id="tab-jsonCursor"/>
                                         <Tab label="PropertyDDS" id="tab-propertyDDS"/>
                                     </Tabs>
@@ -219,16 +222,16 @@ export const InspectorApp = (props: any) => {
                                                         data={json}
                                                     />
                                                 </TabPanel>
-                                                <TabPanel value={tabIndex} index={1}>
-                                                    <ForestTable
+                                                <TabPanel value={tabIndex} index={0}>
+                                                    <ProplikeTable
                                                         readOnly={false}
                                                         width={width}
                                                         height={height}
                                                         {...props}
-                                                        data={forest}
+                                                        data={forestProxy}
                                                     />
                                                 </TabPanel>
-                                                <TabPanel value={tabIndex} index={0}>
+                                                <TabPanel value={tabIndex} index={1}>
                                                     <ProxyTable
                                                         readOnly={false}
                                                         width={width}

--- a/experimental/PropertyDDS/examples/property-inspector/src/inspector.tsx
+++ b/experimental/PropertyDDS/examples/property-inspector/src/inspector.tsx
@@ -27,7 +27,7 @@ import { PropertyTable } from "./propertyInspector/propertyTable";
 import { loadPropertyDDS } from "./propertyInspector/propertyData";
 import { JsonTable } from "./jsonInspector/jsonTable";
 import { ForestTable, getForest } from "./forestInspector/forestTable";
-import { ProxyTable, getForest as getForestProxy } from "./forestInspector/proxyTable";
+import { ProxyTable, getForestProxy } from "./forestInspector/proxyTable";
 
 const useStyles = makeStyles({
     activeGraph: {

--- a/experimental/PropertyDDS/examples/property-inspector/tests/forestProxy.spec.ts
+++ b/experimental/PropertyDDS/examples/property-inspector/tests/forestProxy.spec.ts
@@ -2,16 +2,16 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { JsonableTree, ObjectForest, TextCursor } from "@fluid-internal/tree";
+import { JsonableTree, buildForest } from "@fluid-internal/tree";
 import { brand } from "@fluid-internal/tree/dist/util";
 import { registerSchemas } from "@fluid-experimental/schemas";
 import { PropertyFactory } from "@fluid-experimental/property-properties";
 
-import { getForestProxy } from "../src/forestProxy";
+import { proxifyForest } from "../src/forestProxy";
 import { convertPSetSchema } from "../src/schemaConverter";
 
 describe("Forest proxy", () => {
-	let forest: ObjectForest;
+	let forest;
 	const data: JsonableTree = {
 		type: brand("Test:Person-1.0.0"),
 		fields: {
@@ -33,18 +33,18 @@ describe("Forest proxy", () => {
 	beforeAll(() => registerSchemas(PropertyFactory));
 
 	beforeEach(() => {
-		forest = new ObjectForest();
+		forest = buildForest();
 		convertPSetSchema("Test:Person-1.0.0", forest.schema);
-		// Not sure how best to create data from Schema
-		const cursor = new TextCursor(data);
-		const newRange = forest.add([cursor]);
-		const dst = { index: 0, range: forest.rootField };
-		forest.attachRangeOfChildren(dst, newRange);
 	});
 
 	it("Should be able to proxify forest", () => {
-		const proxy = getForestProxy(forest.allocateCursor(), forest);
+		const proxy: any = proxifyForest(data, forest);
 		expect(proxy).toBeDefined();
 		expect(Object.keys(proxy).length).toBeGreaterThan(0);
+		expect(proxy.name).toMatchObject({ value: "Adam", type: "String" });
+		const { value, type } = proxy.address;
+		expect(value).toBeUndefined();
+		expect(type).toEqual("Test:Address-1.0.0");
+		expect(proxy.address.street).toMatchObject({ value: "treeStreet", type: "String" });
 	});
 });

--- a/experimental/PropertyDDS/examples/schemas/src/person_demo/index.ts
+++ b/experimental/PropertyDDS/examples/schemas/src/person_demo/index.ts
@@ -35,6 +35,7 @@ export default {
 			{ id: "salary", typeid: "Float64" },
 			{ id: "address", typeid: "Test:Address-1.0.0" },
 			{ id: "friends", typeid: "String", context: "map" },
+			{ id: "data", typeid: "String" },
 		],
 	},
 };

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/Field.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/Field.tsx
@@ -11,6 +11,7 @@ import { EnumView } from "./PropertyViews/Enum";
 import { NumberView } from "./PropertyViews/Number";
 import { StringView } from "./PropertyViews/String";
 import { Utils } from "./typeUtils";
+import { isPropertyProxy } from "./propertyInspectorUtils";
 
 function onInlineEditEnd(val: string | number | boolean, props: IEditableValueCellProps) {
     const { rowData } = props;
@@ -19,7 +20,7 @@ function onInlineEditEnd(val: string | number | boolean, props: IEditableValueCe
         val = !isNaN(+val) ? +val : val;
     }
 
-    const proxiedParent = PropertyProxy.proxify(rowData.parent!);
+    const proxiedParent = isPropertyProxy(rowData.parent) ? rowData.parent : PropertyProxy.proxify(rowData.parent!);
     const parentContext = rowData.parent!.getContext();
     try {
         switch (parentContext) {

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
@@ -306,6 +306,7 @@ class InspectorTable<
     const { currentResult, expanded, tableRows, searchExpression, sortBy } = this.state;
     let { foundMatches, childToParentMap } = this.state;
     this.toTableRowOptions.followReferences = followReferences;
+    this.toTableRowOptions.ascending = sortBy.order === TableSortOrder.ASC;
     const newState = {} as Pick<IInspectorTableState, "currentResult" | "expanded" | "foundMatches" | "matchesMap" |
       "searchAbortHandler" | "searchDone" | "searchInProgress" | "searchState" | "tableRows" | "childToParentMap">;
 

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTableTypes.ts
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTableTypes.ts
@@ -135,7 +135,7 @@ export interface IInspectorTableProps<T extends IRowData<T> = any> extends BaseT
   /**
    * The raw data to be visualized.
    */
-  data?: any;
+  data?: T;
   /**
    *  Reference property handler
    */

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/propertyInspectorUtils.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/propertyInspectorUtils.tsx
@@ -484,7 +484,7 @@ export const fillExpanded = (
     }
   }
 };
-const isPropertyProxy = (p: any): p is BaseProxifiedProperty => {
+export const isPropertyProxy = (p: any): p is BaseProxifiedProperty => {
   return p.getProperty && PropertyFactory.instanceOf(p.getProperty(), "BaseProperty");
 };
 const invalidReference = (parentProxy: BaseProxifiedProperty, id: string | number) => {

--- a/experimental/PropertyDDS/packages/property-properties/src/index.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/index.ts
@@ -9,6 +9,7 @@ import { BaseProperty } from './properties/baseProperty';
 import { ContainerProperty } from './properties/containerProperty';
 import { MapProperty } from './properties/mapProperty';
 import { NodeProperty } from './properties/nodeProperty';
+import { NamedNodeProperty } from './properties/namedNodeProperty';
 import { ArrayProperty } from './properties/arrayProperty';
 import { SetProperty } from './properties/setProperty';
 import { StringProperty } from './properties/stringProperty';
@@ -31,6 +32,7 @@ export {
     BaseProperty,
     ContainerProperty,
     MapProperty,
+    NamedNodeProperty,
     NodeProperty,
     ArrayProperty,
     SetProperty,

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -34,7 +34,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
     private readonly dependees: Map<ObjectField | JsonableTree, DisposingDependee> = new Map();
 
     // All cursors that are in the "Current" state. Must be empty when editing.
-    public readonly currentCursors: Set<Cursor> = new Set();
+    public readonly currentCursors: Set<ITreeCursor> = new Set();
 
     public constructor(public readonly anchors: AnchorSet = new AnchorSet()) {
         super("object-forest.ObjectForest");


### PR DESCRIPTION
The last [commit](https://github.com/nedalhy/FluidFramework/pull/7/commits/9fa83a91655952daffee4b18924c0d14657b0610) contains a PoC to render a proxified forest via oob inspector table. A coupling between table elements and PropertyDDS is still too strong, what could be clearly seen from this code.

One could:
- add property if it is part of the given schema
- change property

Delete is not implemented.

Of course, everything is based on an in-memory forest.